### PR TITLE
メモIDの重複確認用のテストケースを追加

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -24,10 +24,3 @@ task :json_data do
     JSON.dump(json, file)
   end
 end
-
-task :add_memos, :count do |task, args|
-  count = args[:count].to_i
-  Parallel.each(1..count, in_threads: 10) do
-    Memo.create("#{Faker::Lorem.paragraph(sentence_count: 20)}")
-  end
-end

--- a/test/memo_file_store_test.rb
+++ b/test/memo_file_store_test.rb
@@ -15,7 +15,7 @@ class MemoFileStoreTest < Minitest::Test
     end
 
     def test_memo_insertion_by_multithread
-        # メモの保存数が0であることい
+        # メモの保存数が0であること
         memos = @memo_file_store.findAll
         assert_equal 0, memos.count
 

--- a/test/memo_file_store_test.rb
+++ b/test/memo_file_store_test.rb
@@ -1,0 +1,42 @@
+require "minitest/autorun"
+require "faker"
+require "parallel"
+require_relative "../lib/memo_file_store.rb"
+
+class MemoFileStoreTest < Minitest::Test 
+    def setup
+      @memo_path = "test/memo.json"
+
+      # テスト用のjsonファイルが存在する場合は削除する
+      File.delete(@memo_path) if File.exist?(@memo_path)
+
+      # MemoFileStoreインスタンスを初期化
+      @memo_file_store = MemoFileStore.new(@memo_path)
+    end
+
+    def test_memo_insertion_by_multithread
+        # メモの保存数が0であることい
+        memos = @memo_file_store.findAll
+        assert_equal 0, memos.count
+
+        # 10スレッドを生成して、メモを500件追加
+        Parallel.each(1..500, in_threads: 10) do
+          @memo_file_store.create("#{Faker::Lorem.paragraph(sentence_count: 20)}")
+        end
+
+        # メモの保存数が500であること
+        memos = @memo_file_store.findAll
+        assert_equal 500, memos.count
+
+        # 最後に追加されたメモのIDが500であること
+        assert_equal 500, memos.last["memo_id"]
+
+        # 最後から２番目に追加されたメモのIDが499であること
+        assert_equal 499, memos[-2]["memo_id"]
+    end
+
+    def teardown
+      # テスト用のjsonファイルを削除する
+      File.delete(@memo_path) if File.exist?(@memo_path)
+    end
+end

--- a/test/memo_file_store_test.rb
+++ b/test/memo_file_store_test.rb
@@ -1,42 +1,44 @@
+# frozen_string_literal: true
+
 require "minitest/autorun"
 require "faker"
 require "parallel"
 require_relative "../lib/memo_file_store.rb"
 
-class MemoFileStoreTest < Minitest::Test 
-    def setup
-      @memo_path = "test/memo.json"
+class MemoFileStoreTest < Minitest::Test
+  def setup
+    @memo_path = "test/memo.json"
 
-      # テスト用のjsonファイルが存在する場合は削除する
-      File.delete(@memo_path) if File.exist?(@memo_path)
+    # テスト用のjsonファイルが存在する場合は削除する
+    File.delete(@memo_path) if File.exist?(@memo_path)
 
-      # MemoFileStoreインスタンスを初期化
-      @memo_file_store = MemoFileStore.new(@memo_path)
+    # MemoFileStoreインスタンスを初期化
+    @memo_file_store = MemoFileStore.new(@memo_path)
+  end
+
+  def test_memo_insertion_by_multithread
+    # メモの保存数が0であること
+    memos = @memo_file_store.findAll
+    assert_equal 0, memos.count
+
+    # 10スレッドを生成して、メモを500件追加
+    Parallel.each(1..500, in_threads: 10) do
+      @memo_file_store.create("#{Faker::Lorem.paragraph(sentence_count: 20)}")
     end
 
-    def test_memo_insertion_by_multithread
-        # メモの保存数が0であること
-        memos = @memo_file_store.findAll
-        assert_equal 0, memos.count
+    # メモの保存数が500であること
+    memos = @memo_file_store.findAll
+    assert_equal 500, memos.count
 
-        # 10スレッドを生成して、メモを500件追加
-        Parallel.each(1..500, in_threads: 10) do
-          @memo_file_store.create("#{Faker::Lorem.paragraph(sentence_count: 20)}")
-        end
+    # 最後に追加されたメモのIDが500であること
+    assert_equal 500, memos.last["memo_id"]
 
-        # メモの保存数が500であること
-        memos = @memo_file_store.findAll
-        assert_equal 500, memos.count
+    # 最後から２番目に追加されたメモのIDが499であること
+    assert_equal 499, memos[-2]["memo_id"]
+  end
 
-        # 最後に追加されたメモのIDが500であること
-        assert_equal 500, memos.last["memo_id"]
-
-        # 最後から２番目に追加されたメモのIDが499であること
-        assert_equal 499, memos[-2]["memo_id"]
-    end
-
-    def teardown
-      # テスト用のjsonファイルを削除する
-      File.delete(@memo_path) if File.exist?(@memo_path)
-    end
+  def teardown
+    # テスト用のjsonファイルを削除する
+    File.delete(@memo_path) if File.exist?(@memo_path)
+  end
 end


### PR DESCRIPTION
# 概要

メモの作成処理を同時に実行した場合に、メモIDが重複しないことをテストする。

# テスト内容
* メモを作成する前に、メモの件数が0件であること
* 10個のスレッドで500件のメモを作成した場合に、以下の事象になることを確認する。
  * メモの件数が合計で500になること
  * 最後に追加したメモのIDが500であること
  * 最後から２番目に追加したメモのIDが499であること