### PR TITLE
変数名・メソッド名をスネークケースに変更

### DIFF
--- a/controllers/memos_controller.rb
+++ b/controllers/memos_controller.rb
@@ -34,7 +34,7 @@ class MemosController < Sinatra::Base
   end
 
   get "/" do
-    @memos = Memo.findAll
+    @memos = Memo.find_all
     @require_new_link = true
     erb :index
   end

--- a/lib/memo_db_store.rb
+++ b/lib/memo_db_store.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class MemoDbStore
-  def findAll
+  def find_all
   end
 
   def find(memo_id)

--- a/lib/memo_file_store.rb
+++ b/lib/memo_file_store.rb
@@ -17,7 +17,7 @@ class MemoFileStore
     end
   end
 
-  def findAll
+  def find_all
     MemoFileLock.synchronized(@file_path, "r") do |file|
       load_json(file)
     end
@@ -68,12 +68,12 @@ class MemoFileStore
           json.empty? ? 1 : json.last["memo_id"] + 1
         end.call
 
-        currentTime = Time.now.iso8601
+        current_time = Time.now.iso8601
         created_item = {
           "memo_id" => memo_id,
           "content" => content,
-          "created_at" => currentTime,
-          "updated_at" => currentTime,
+          "created_at" => current_time,
+          "updated_at" => current_time,
         }
 
         json << created_item

--- a/lib/memo_storable.rb
+++ b/lib/memo_storable.rb
@@ -5,8 +5,8 @@ module MemoStorable
     @store = store
   end
 
-  def findAll
-    @store.findAll
+  def find_all
+    @store.find_all
   end
 
   def find(memo_id)

--- a/models/memo.rb
+++ b/models/memo.rb
@@ -5,8 +5,8 @@ require_relative "memo_dao.rb"
 class Memo
   attr_accessor :memo_id, :content, :created_at, :updated_at
 
-  def self.findAll
-    MemoDao.findAll.map(&method(:convert))
+  def self.find_all
+    MemoDao.find_all.map(&method(:convert))
   end
 
   def self.find(memo_id)


### PR DESCRIPTION
# 概要
変数名・メソッド名がアッパーケースになっているのでスネークケースに変更する。

# 修正内容
* メソッドのfindAllをfind_allに変更
* 変数のcurrentTimeをcurrent_timeに変更
