### PR TITLE
メモIDの重複確認用のテストケースを追加

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -24,10 +24,3 @@ task :json_data do
     JSON.dump(json, file)
   end
 end
-
-task :add_memos, :count do |task, args|
-  count = args[:count].to_i
-  Parallel.each(1..count, in_threads: 10) do
-    Memo.create("#{Faker::Lorem.paragraph(sentence_count: 20)}")
-  end
-end

--- a/controllers/memos_controller.rb
+++ b/controllers/memos_controller.rb
@@ -34,7 +34,7 @@ class MemosController < Sinatra::Base
   end
 
   get "/" do
-    @memos = Memo.findAll
+    @memos = Memo.find_all
     @require_new_link = true
     erb :index
   end

--- a/lib/memo_db_store.rb
+++ b/lib/memo_db_store.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class MemoDbStore
-  def findAll
+  def find_all
   end
 
   def find(memo_id)

--- a/lib/memo_file_store.rb
+++ b/lib/memo_file_store.rb
@@ -17,7 +17,7 @@ class MemoFileStore
     end
   end
 
-  def findAll
+  def find_all
     MemoFileLock.synchronized(@file_path, "r") do |file|
       load_json(file)
     end
@@ -68,12 +68,12 @@ class MemoFileStore
           json.empty? ? 1 : json.last["memo_id"] + 1
         end.call
 
-        currentTime = Time.now.iso8601
+        current_time = Time.now.iso8601
         created_item = {
           "memo_id" => memo_id,
           "content" => content,
-          "created_at" => currentTime,
-          "updated_at" => currentTime,
+          "created_at" => current_time,
+          "updated_at" => current_time,
         }
 
         json << created_item

--- a/lib/memo_storable.rb
+++ b/lib/memo_storable.rb
@@ -5,8 +5,8 @@ module MemoStorable
     @store = store
   end
 
-  def findAll
-    @store.findAll
+  def find_all
+    @store.find_all
   end
 
   def find(memo_id)

--- a/models/memo.rb
+++ b/models/memo.rb
@@ -5,8 +5,8 @@ require_relative "memo_dao.rb"
 class Memo
   attr_accessor :memo_id, :content, :created_at, :updated_at
 
-  def self.findAll
-    MemoDao.findAll.map(&method(:convert))
+  def self.find_all
+    MemoDao.find_all.map(&method(:convert))
   end
 
   def self.find(memo_id)

--- a/test/memo_file_store_test.rb
+++ b/test/memo_file_store_test.rb
@@ -15,7 +15,7 @@ class MemoFileStoreTest < Minitest::Test
     end
 
     def test_memo_insertion_by_multithread
-        # メモの保存数が0であることい
+        # メモの保存数が0であること
         memos = @memo_file_store.findAll
         assert_equal 0, memos.count
 

--- a/test/memo_file_store_test.rb
+++ b/test/memo_file_store_test.rb
@@ -1,0 +1,42 @@
+require "minitest/autorun"
+require "faker"
+require "parallel"
+require_relative "../lib/memo_file_store.rb"
+
+class MemoFileStoreTest < Minitest::Test 
+    def setup
+      @memo_path = "test/memo.json"
+
+      # テスト用のjsonファイルが存在する場合は削除する
+      File.delete(@memo_path) if File.exist?(@memo_path)
+
+      # MemoFileStoreインスタンスを初期化
+      @memo_file_store = MemoFileStore.new(@memo_path)
+    end
+
+    def test_memo_insertion_by_multithread
+        # メモの保存数が0であることい
+        memos = @memo_file_store.findAll
+        assert_equal 0, memos.count
+
+        # 10スレッドを生成して、メモを500件追加
+        Parallel.each(1..500, in_threads: 10) do
+          @memo_file_store.create("#{Faker::Lorem.paragraph(sentence_count: 20)}")
+        end
+
+        # メモの保存数が500であること
+        memos = @memo_file_store.findAll
+        assert_equal 500, memos.count
+
+        # 最後に追加されたメモのIDが500であること
+        assert_equal 500, memos.last["memo_id"]
+
+        # 最後から２番目に追加されたメモのIDが499であること
+        assert_equal 499, memos[-2]["memo_id"]
+    end
+
+    def teardown
+      # テスト用のjsonファイルを削除する
+      File.delete(@memo_path) if File.exist?(@memo_path)
+    end
+end

--- a/test/memo_file_store_test.rb
+++ b/test/memo_file_store_test.rb
@@ -18,7 +18,7 @@ class MemoFileStoreTest < Minitest::Test
 
   def test_memo_insertion_by_multithread
     # メモの保存数が0であること
-    memos = @memo_file_store.findAll
+    memos = @memo_file_store.find_all
     assert_equal 0, memos.count
 
     # 10スレッドを生成して、メモを500件追加
@@ -27,7 +27,7 @@ class MemoFileStoreTest < Minitest::Test
     end
 
     # メモの保存数が500であること
-    memos = @memo_file_store.findAll
+    memos = @memo_file_store.find_all
     assert_equal 500, memos.count
 
     # 最後に追加されたメモのIDが500であること

--- a/test/memo_file_store_test.rb
+++ b/test/memo_file_store_test.rb
@@ -1,42 +1,44 @@
+# frozen_string_literal: true
+
 require "minitest/autorun"
 require "faker"
 require "parallel"
 require_relative "../lib/memo_file_store.rb"
 
-class MemoFileStoreTest < Minitest::Test 
-    def setup
-      @memo_path = "test/memo.json"
+class MemoFileStoreTest < Minitest::Test
+  def setup
+    @memo_path = "test/memo.json"
 
-      # テスト用のjsonファイルが存在する場合は削除する
-      File.delete(@memo_path) if File.exist?(@memo_path)
+    # テスト用のjsonファイルが存在する場合は削除する
+    File.delete(@memo_path) if File.exist?(@memo_path)
 
-      # MemoFileStoreインスタンスを初期化
-      @memo_file_store = MemoFileStore.new(@memo_path)
+    # MemoFileStoreインスタンスを初期化
+    @memo_file_store = MemoFileStore.new(@memo_path)
+  end
+
+  def test_memo_insertion_by_multithread
+    # メモの保存数が0であること
+    memos = @memo_file_store.findAll
+    assert_equal 0, memos.count
+
+    # 10スレッドを生成して、メモを500件追加
+    Parallel.each(1..500, in_threads: 10) do
+      @memo_file_store.create("#{Faker::Lorem.paragraph(sentence_count: 20)}")
     end
 
-    def test_memo_insertion_by_multithread
-        # メモの保存数が0であること
-        memos = @memo_file_store.findAll
-        assert_equal 0, memos.count
+    # メモの保存数が500であること
+    memos = @memo_file_store.findAll
+    assert_equal 500, memos.count
 
-        # 10スレッドを生成して、メモを500件追加
-        Parallel.each(1..500, in_threads: 10) do
-          @memo_file_store.create("#{Faker::Lorem.paragraph(sentence_count: 20)}")
-        end
+    # 最後に追加されたメモのIDが500であること
+    assert_equal 500, memos.last["memo_id"]
 
-        # メモの保存数が500であること
-        memos = @memo_file_store.findAll
-        assert_equal 500, memos.count
+    # 最後から２番目に追加されたメモのIDが499であること
+    assert_equal 499, memos[-2]["memo_id"]
+  end
 
-        # 最後に追加されたメモのIDが500であること
-        assert_equal 500, memos.last["memo_id"]
-
-        # 最後から２番目に追加されたメモのIDが499であること
-        assert_equal 499, memos[-2]["memo_id"]
-    end
-
-    def teardown
-      # テスト用のjsonファイルを削除する
-      File.delete(@memo_path) if File.exist?(@memo_path)
-    end
+  def teardown
+    # テスト用のjsonファイルを削除する
+    File.delete(@memo_path) if File.exist?(@memo_path)
+  end
 end


### PR DESCRIPTION
# 概要

メモの作成処理を同時に実行した場合に、メモIDが重複しないことをテストする。

# テスト内容
* メモを作成する前に、メモの件数が0件であること
* 10個のスレッドで500件のメモを作成した場合に、以下の事象になることを確認する。
  * メモの件数が合計で500になること
  * 最後に追加したメモのIDが500であること
  * 最後から２番目に追加したメモのIDが499であること

# テスト結果

テストがパスすることを確認した。

![image](https://user-images.githubusercontent.com/13811034/75248973-975aef80-5818-11ea-8ced-748ebcd3d5c1.png)
